### PR TITLE
docs: add pr and issue templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,47 @@
+---
+name: Bug report
+about: Create a report to help us improve
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Create a Bug Report
+
+## Prerequisites
+
+Please answer the following questions for yourself before submitting an issue.
+
+- [ ] I am running the latest version.
+- [ ] I checked the documentation and found no answer.
+- [ ] I checked to make sure that this issue has not already been filed.
+- [ ] I'm reporting the issue to the correct repository.
+
+## Expected Behavior
+
+Please describe the behavior you are expecting.
+
+## Current Behavior
+
+What is the current behavior?
+
+## Steps to Reproduce
+
+Please provide detailed steps for reproducing the issue.
+
+1. step 1
+2. step 2
+3. and so on
+
+## Context
+Make sure to add **all the information needed to understand the bug** so that someone can help.
+
+- [ ] Provide a **minimal code snippet** example that reproduces the bug.
+- [ ] Provide **screenshots** or **gif's** where appropriate.
+- [ ] Provide the full error / stacktrace if applicable.
+- [ ] What **version** of CH5 Components Library are you using?
+
+## Failure Logs
+
+Please include any relevant log snippets or files here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,22 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+title: ''
+labels: ''
+assignees: ''
+
+---
+
+# Create a Feature Request
+
+## Is your feature request related to a problem? 
+Please provide a clear and concise description of what the problem is.
+
+##Describe the solution you'd like
+A clear and concise description of what you want to happen.
+
+##Describe alternatives you've considered
+A clear and concise description of any alternative solutions or features you've considered.
+
+##Additional context
+Add any other context or screenshots about the feature request here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,25 @@
+# Description
+
+Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.
+
+Fixes # (issue)
+
+## Type of change
+
+Please delete options that are not relevant.
+
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
+- [ ] This change requires a documentation update
+
+# Checklist:
+
+- [ ] My code follows the style guidelines of this project
+- [ ] I have performed a self-review of my own code
+- [ ] I have commented my code, particularly in hard-to-understand areas
+- [ ] I have made corresponding changes to the documentation
+- [ ] My changes generate no new warnings
+- [ ] I have added tests that prove my fix is effective or that my feature works
+- [ ] New and existing unit tests pass locally with my changes
+- [ ] Any dependent changes have been merged and published in downstream modules


### PR DESCRIPTION
# Description
- Added standard PR and ISSUE templates

@crazvansandu please check if some adjustments need to be made, I copied them from the ThemeEditor and they seemed alright at a first glance.