### PR TITLE
fix(ch5-remote-logger): remove slashes from input when building regex

### DIFF
--- a/crestron-components-lib-tests/src/tests/ch5-logger/helpers/LogMessagesFilterTests.ts
+++ b/crestron-components-lib-tests/src/tests/ch5-logger/helpers/LogMessagesFilterTests.ts
@@ -1,0 +1,35 @@
+// Copyright (C) 2018 to the present, Crestron Electronics, Inc.
+// All rights reserved.
+// No part of this software may be reproduced in any form, machine
+// or natural, without the express written consent of Crestron Electronics.
+// Use of this source code is subject to the terms of the Crestron Software License Agreement
+// under which you licensed this source code.
+
+import { expect } from "chai";
+import { LogMessagesFilter } from "../../../../../crestron-components-lib/src/ch5-logger/helpers";
+
+let logMessageFilter: LogMessagesFilter;
+
+describe('Ch5-Remote-Logger LogMessagesFilter Tests', () => {
+  beforeEach(() => {
+    logMessageFilter = new LogMessagesFilter();
+  });
+
+  it('LogMessageFilter will match regex without slashes', () => {
+    logMessageFilter.regularExpression = '[0-9]';
+
+    expect(logMessageFilter.isMatchingFilterRegex('111')).to.equal(true);
+  });
+
+  it('LogMessageFilter will match regex with slashes', () => {
+    logMessageFilter.regularExpression = '/[0-9]/';
+
+    expect(logMessageFilter.isMatchingFilterRegex('111')).to.equal(true);
+  });
+
+    it('LogMessageFilter regularExpression setter will remove slashes', () => {
+    logMessageFilter.regularExpression = '/[0-9]/';
+
+    expect(logMessageFilter.regularExpression).to.equal('[0-9]');
+  });
+});

--- a/crestron-components-lib/src/ch5-logger/helpers/LogMessagesFilter.ts
+++ b/crestron-components-lib/src/ch5-logger/helpers/LogMessagesFilter.ts
@@ -17,9 +17,10 @@ import {Ch5Debug} from '../../ch5-core/ch5-debug';
  */
 export class LogMessagesFilter {
 
+    private _regularExpression: string = '';
+
     public level: LogLevelEnum;
     public source: string = Ch5Debug.getConfigKeyValue(Ch5Debug.DEBUG_MESSAGE_FILTER_SOURCE_KEY) as string;
-    public regularExpression: string = '';
 
     /**
      * If there is a configuration for default log level, use it
@@ -32,8 +33,27 @@ export class LogMessagesFilter {
 
     constructor(level?: LogLevelEnum, source?: string, regexStr?: string) {
         this.level = !isNil(level) ? level : LogMessagesFilter.getDefaultLevel();
-        this.regularExpression = regexStr ? regexStr : this.regularExpression;
+        this.regularExpression = regexStr ? regexStr : this._regularExpression;
         this.source = source ? source : this.source;
+    }
+
+    public get regularExpression():string {
+        return this._regularExpression;
+    }
+
+    public set regularExpression(value: string) {
+        if (isNil(value)) {
+            this._regularExpression = '';
+            return;
+        }
+
+        if (value.charAt(0) === '/' && value.charAt(value.length - 1) === '/') {
+            const lastSlashPos = value.lastIndexOf('/');
+            this._regularExpression = value.substr(1).substring(0, lastSlashPos - 1);
+            return;
+        }
+
+        this._regularExpression = value;
     }
 
     public undateSourceFromConfig() {


### PR DESCRIPTION
# Description

If you would add a regex with slashes, it would build an invalid expression, and it wouldn't match what it should.
For this purpose I filter out the slashes to build the desired regex.

Fixes # [CH5C-775](https://crestroneng.atlassian.net/browse/CH5C-775)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
