### PR TITLE
fix(showcase): add missing emulator entry for first select option

### DIFF
--- a/showcase-app/emulator-scenarios/scenario-ch5-select-multi-selection-signals.json
+++ b/showcase-app/emulator-scenarios/scenario-ch5-select-multi-selection-signals.json
@@ -91,6 +91,18 @@
     },
     {
       "type": "b",
+      "event": "option_2_0_on_click",
+      "trigger": true,
+      "actions": [
+        {
+          "state": "option_2_0_selected",
+          "type": "b",
+          "logic": "toggle"
+        }
+      ]
+    },
+    {
+      "type": "b",
       "event": "option_2_1_on_click",
       "trigger": true,
       "actions": [


### PR DESCRIPTION
# Description

- add a missing event for the first select option

Fixes https://crestroneng.atlassian.net/browse/CH5C-744

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
