### PR TITLE
fix(ch5-list): remove extra trailing element when using buffered items

### DIFF
--- a/crestron-components-lib/src/ch5-list/ch5-list-animation.ts
+++ b/crestron-components-lib/src/ch5-list/ch5-list-animation.ts
@@ -369,11 +369,13 @@ export class Ch5ListAnimation extends Ch5ListAbstractHelper {
             return this._list.sizeResolver.hiddenListSize;
         }
 
+        this._templateHelper.updateViewportSize();
+
         const itemsPerPage = this._list.getItemsPerPage();
         const firstItemSize = this._list.getItemSize();
         const definedListSize = this._list.size || 0;
         const listSize = (definedListSize - itemsPerPage) * firstItemSize; 
-        
+
         return listSize;
     }
 

--- a/crestron-components-lib/src/ch5-list/ch5-list-buffered-items.ts
+++ b/crestron-components-lib/src/ch5-list/ch5-list-buffered-items.ts
@@ -5,8 +5,6 @@
 // Use of this source code is subject to the terms of the Crestron Software License Agreement
 // under which you licensed this source code.
 
-import { Ch5List } from "./ch5-list";
-import { Ch5ListTemplate } from "./ch5-list-template";
 import { Ch5ListAbstractHelper } from "./ch5-list-abstract-helper";
 
 export interface ICh5ListBufferedItems {
@@ -88,12 +86,12 @@ export class Ch5ListBufferedItems extends Ch5ListAbstractHelper {
             const maxOffset = (this._list.items.length - this._list.getItemsPerPage()) * this._list.getItemSize();
             const isLtr = this._list.isLtr();
             // if drag orientation is to left and drag position is in the last page of items then append forward buffer items
-            if ((isLtr && newPosition < -maxOffset) 
+            if ((isLtr && newPosition < -maxOffset)
                 || (!isLtr && newPosition < maxOffset)
             ) {
                 this._appendForwardBufferedItemsToList(
-                    newPosition, 
-                    !this._list.isHorizontal, 
+                    newPosition,
+                    !this._list.isHorizontal,
                     this._list.bufferAmount
                 );
             }
@@ -104,20 +102,18 @@ export class Ch5ListBufferedItems extends Ch5ListAbstractHelper {
     private _bufferItemsForward() {
         const size: number = Number(this._list.size);
         const uid: string = this._list.divList.id;
-        const firstRenderVisibleItemsNr = this._list.getFirstRenderVisibleItemsNr();
+        const listChildrenLength = this._list.divList.children.length;
+        const bufferAmountValue = Number(this._list.bufferAmount);
 
-        let lastBufferedIndex: number = this._list.bufferedItems.bufferForwardStartIndex - 1 + Number(this._list.bufferAmount);
-        if (lastBufferedIndex > this._list.bufferedItems.bufferBackwardsStartIndex + firstRenderVisibleItemsNr) {
-            // avoid buffering already buffered elems
-            lastBufferedIndex = this._list.bufferedItems.bufferBackwardsStartIndex + firstRenderVisibleItemsNr;
-        }
+        let lastBufferedIndex: number = listChildrenLength + bufferAmountValue;
+
         if (lastBufferedIndex > size) {
-            // make sure lastBufferedIndex doesn't exceed list size
             lastBufferedIndex = size;
         }
 
-        for (let index = this._list.bufferedItems.bufferForwardStartIndex; index <= lastBufferedIndex; index++) {
-            this._list.bufferedItems.forwardBufferedItems.push(this._list.templateHelper.processTemplate(uid, index, this._list.templateVars));
+        for (let index = listChildrenLength; index < lastBufferedIndex; index++) {
+            const item = this._list.templateHelper.processTemplate(uid, index, this._list.templateVars);
+            this._list.bufferedItems.forwardBufferedItems.push(item);
         }
 
         // prepare next buffer start

--- a/crestron-components-lib/src/ch5-list/ch5-list-template.ts
+++ b/crestron-components-lib/src/ch5-list/ch5-list-template.ts
@@ -26,7 +26,7 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
 
     /**
      * Tracks the endless attribute
-     * 
+     *
      * @type {boolean}
      */
     public endless: boolean = false;
@@ -81,7 +81,7 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
     /**
      * Process items (template) for each IDX
      * @param uid  = list id
-     * @param index = idx increment starting from 1
+     * @param index = idx increment starting from 0
      */
     public processTemplate(uid: string, index: number, templateVars: string | null): HTMLElement {
         this._list.info(`ch5-list-template - processTemplate`);
@@ -245,10 +245,12 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
         // update first buffered elements
         this._list._bufferedItems.bufferActive = this._list._canUseBufferAmount(firstRenderVisibleItemsNr);
         if (this._list._bufferedItems.bufferActive) {
-            this._list._bufferedItems.bufferForwardStartIndex = firstRenderVisibleItemsNr + 1;
+            // orig: this._list._bufferedItems.bufferForwardStartIndex = firstRenderVisibleItemsNr + 1;
+            this._list._bufferedItems.bufferForwardStartIndex = firstRenderVisibleItemsNr;
             // always init bufferBackwardsStartIndex, even list is not endless
             // we need this when buffered items are created
             if (this._list.size !== null) {
+                // orig: this._list._bufferedItems.bufferBackwardsStartIndex = Number(this._list.size);
                 this._list._bufferedItems.bufferBackwardsStartIndex = Number(this._list.size);
             }
 
@@ -530,12 +532,10 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
         if (this._list.divList.childElementCount > 0) {
             const divListSizeDetails: ClientRect | DOMRect = this._list.divList.getBoundingClientRect();
             const firstItem = this._list.divList.children[0] as HTMLElement;
-            const listViewportBoundingRect: ClientRect | DOMRect = this._list.getBoundingClientRect();
 
             this._list.divListWidth = divListSizeDetails.width;
             this._list.divListHeight = divListSizeDetails.height;
-            this._list.viewportClientHeight = listViewportBoundingRect.height;
-            this._list.viewportClientWidth = listViewportBoundingRect.width;
+            this.updateViewportSize();
 
             setTimeout(() => {
                 // setting the list offset and client sizes
@@ -544,8 +544,7 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
                 this._list.itemOffsetWidth = firstItem.offsetWidth;
                 this._list.divListWidth = divListSizeDetails.width;
                 this._list.divListHeight = divListSizeDetails.height;
-                this._list.viewportClientHeight = listViewportBoundingRect.height;
-                this._list.viewportClientWidth = listViewportBoundingRect.width;
+                this.updateViewportSize();
             });
 
             if (firstItem instanceof HTMLElement) {
@@ -559,9 +558,19 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
     }
 
     /**
+     * Updates the viewport size
+     * 
+     */
+    public updateViewportSize() {
+        const listViewportBoundingRect: ClientRect | DOMRect = this._list.getBoundingClientRect();
+        this._list.viewportClientHeight = listViewportBoundingRect.height;
+        this._list.viewportClientWidth = listViewportBoundingRect.width;
+    }
+
+    /**
      * Resolve the endless list when the number of items visible in the list
      * is the same as the list size. Then is not need the list to be endless.
-     * 
+     *
      * @return {void}
      */
     public resolveEndlessViewportSize(): void {
@@ -594,7 +603,7 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
         let pxScrollPosition;
         let direction = 1;
 
-        // horizontal rtl needs special handling; all other cases are the same        
+        // horizontal rtl needs special handling; all other cases are the same
         if ((this._list.isVertical || this._list.direction === Ch5Common.DIRECTION[0]) && position > 0) {
             percentageScrollPosition = 100 - percentageScrollPosition;
             direction = -1;

--- a/crestron-components-lib/src/ch5-list/ch5-list.ts
+++ b/crestron-components-lib/src/ch5-list/ch5-list.ts
@@ -749,7 +749,7 @@ export class Ch5List extends Ch5Common implements ICh5ListAttributes {
             numberOfItems = this.viewportClientHeight / this.itemOffsetHeight;
         }
 
-        return Math.floor(numberOfItems);
+        return numberOfItems;
     }
 
     /**

--- a/showcase-app/partials/ch5-list/buffer-amount/ex1-html.njk
+++ b/showcase-app/partials/ch5-list/buffer-amount/ex1-html.njk
@@ -2,8 +2,8 @@
 <p>When scrolling this list and reach the end of the loaded elements a new group of buffered elements will be added.
     This will continue until all the elements have been loaded</p>
 
-<ch5-list id="demo-list-1"
-           size="500"
+<ch5-list
+           size="50"
            orientation="horizontal"
            indexId="idx"
            minWidth="250px"
@@ -13,11 +13,29 @@
            itemWidth="125px"
            itemHeight="75px"
            scrollbar="true"
-           bufferAmount="20">
+           bufferAmount="10">
     <template>
         <div class="horizontal-list-item">
             <span>item_{{idx}}</span>
         </div>
     </template>
 </ch5-list>
+
+<p>Example without setting the maxWidth attribute.</p>
+    <ch5-list
+        size="50"
+        orientation="horizontal"
+        indexId="idx"
+        minHeight="100px"
+        maxHeight="500px"
+        itemWidth="100px"
+        itemHeight="75px"
+        scrollbar="true"
+        bufferAmount="10" >
+        <template>
+            <div class="horizontal-list-item">
+                <span>item {{idx}}</span>
+            </div>
+        </template>
+    </ch5-list>
 {% endraw %}


### PR DESCRIPTION
# Description

When using the bufferAmount attribute, the list would add an extra element.
So for size=50 and bufferAmount=20, you would have 51 items from 0 to 50, instead of 50 items from 0 to 49.

Fixes # [CH5C-113](https://crestroneng.atlassian.net/browse/CH5C-113)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
