### PR TITLE
fix(showcase-app): wrap ch5-textinput minmaxlength attributes js in document.ready()

### DIFF
--- a/showcase-app/partials/ch5-textinput/attributes/minmaxlength/ex1-js.njk
+++ b/showcase-app/partials/ch5-textinput/attributes/minmaxlength/ex1-js.njk
@@ -1,10 +1,11 @@
-var input = document.querySelector('#minLengthForm input[type="text"]');
-var form = document.querySelector('#minLengthForm');
+$(document).ready(() => {
+    var form = document.getElementById('minLengthForm');
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+    })
 
-form.addEventListener('submit', function(e) {
-  e.preventDefault();
-})
-
-input.addEventListener('change', function(e) {
-  console.log(e.target.validity);
+    var input = form.querySelector('input[type="text"]');
+    input.addEventListener('change', function(e) {
+      console.log(e.target.validity);
+    })
 })

--- a/showcase-app/partials/ch5-textinput/attributes/minmaxlength/ex2-js.njk
+++ b/showcase-app/partials/ch5-textinput/attributes/minmaxlength/ex2-js.njk
@@ -1,10 +1,11 @@
-var input = document.querySelector('#maxLengthForm input[type="text"]');
-var form = document.querySelector('#maxLengthForm');
+$(document).ready(() => {
+    var form = document.querySelector('#maxLengthForm');
+    form.addEventListener('submit', function(e) {
+      e.preventDefault();
+    })
 
-form.addEventListener('submit', function(e) {
-  e.preventDefault();
-})
-
-input.addEventListener('change', function(e) {
-  console.log(e.target.validity);
+    var input = form.querySelector('input[type="text"]');
+    input.addEventListener('change', function(e) {
+      console.log(e.target.validity);
+    })
 })


### PR DESCRIPTION
# Description

input variable was null - Uncaught TypeError: Cannot read property 'addEventListener' of null
The input inside ch5-textinput was not rendered when the JS code was executed.

http://127.0.0.1:8082/ch5-textinput/attribute-minmaxlength.html

Fixes # [CH5C-889](https://crestroneng.atlassian.net/browse/CH5C-889)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
