### PR TITLE
Bug/ch5 c 840

### DIFF
--- a/crestron-components-lib/src/ch5-background/ch5-background.ts
+++ b/crestron-components-lib/src/ch5-background/ch5-background.ts
@@ -1029,10 +1029,19 @@ export class Ch5Background extends Ch5Common implements ICh5BackgroundAttributes
             const leftOffset = this._elCanvas.getBoundingClientRect().left;
             this._videoRes.left = this._videoRes.left - leftOffset;
             this._videoRes.top = this._videoRes.top - topOffset;
-
             if (this._videoRes.top < 0 || this._videoRes.left < 0) {
                 return;
             }
+            // Avoiding negative values and decimal values in video and background
+            if (this._videoRes.left > 0 && this._videoRes.left < 1) {
+                this._videoRes.left = 0;
+            }
+            if (this._videoRes.top > 0 && this._videoRes.top < 1) {
+                this._videoRes.top = 0;
+            }
+            this._videoRes.left = Math.ceil(this._videoRes.left);
+            this._videoRes.top = Math.ceil(this._videoRes.top);
+
             const index = this._videoDimensions.findIndex((item: IVideoResponse) => item.id === this._videoRes.id);
             if (index > -1) {
                 this._videoDimensions[index] = this._videoRes;

--- a/crestron-components-lib/src/ch5-common/ch5-common.ts
+++ b/crestron-components-lib/src/ch5-common/ch5-common.ts
@@ -232,7 +232,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
 
     /**
      * Ch5 internal unique ID with Increment
-     */    
+     */
     protected _ch5Id: number = 0;
 
     /**
@@ -306,6 +306,13 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
     public elementIsInViewPort: boolean = true;
 
     /**
+     * Whenever the target meets a threshold specified for the IntersectionObserver, 
+     * the callback is invoked. The callback receives a list of IntersectionObserverEntry 
+     * objects 
+     */
+    public elementIntersectionEntry: IntersectionObserverEntry = {} as IntersectionObserverEntry;
+
+    /**
      *
      * boolean value - element is visible or not
      */
@@ -334,7 +341,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
             if (newValue !== '' && newValue !== this.currentLanguage) {
                 this.currentLanguage = newValue;
                 Object.keys(this.translatableObjects).forEach((propertyToTranslate: string) => {
-                    let propertyReference: {[key: string]: string} = this as {};
+                    let propertyReference: { [key: string]: string } = this as {};
 
                     if (propertyReference[propertyToTranslate as string] === undefined && propertyReference['attrModel' as string] !== undefined) {
                         propertyReference = propertyReference['attrModel' as string] as {};
@@ -381,16 +388,16 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
      * @return {number}
      */
     public static extractMeasurementNumber(sizeValue: string): number {
-      const pattern = new RegExp("^-?\\d+\\.?\\d*");
-      let n: number = 0;
-      if (sizeValue !== null && sizeValue !== undefined) {
-        const matchedValues = sizeValue.match(pattern);
+        const pattern = new RegExp("^-?\\d+\\.?\\d*");
+        let n: number = 0;
+        if (sizeValue !== null && sizeValue !== undefined) {
+            const matchedValues = sizeValue.match(pattern);
 
-        if (matchedValues !== null && matchedValues[0] !== undefined) {
-          n = Number(matchedValues[0]);
+            if (matchedValues !== null && matchedValues[0] !== undefined) {
+                n = Number(matchedValues[0]);
+            }
         }
-      }
-      return n;
+        return n;
     }
 
     /**
@@ -418,11 +425,11 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
 
         switch (measurementUnit) {
             case 'vh':
-            _size = Ch5Common.convertVhUnitsToPx(size);
-            break;
+                _size = Ch5Common.convertVhUnitsToPx(size);
+                break;
             case 'vw':
-            _size = Ch5Common.convertVwUnitsToPx(size);
-            break;
+                _size = Ch5Common.convertVwUnitsToPx(size);
+                break;
         }
 
         return Math.round(_size);
@@ -558,7 +565,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
         const translationUtility = Ch5TranslationUtility.getInstance();
         const isTranslatableValue = translationUtility.isTranslationIdentifier(valueToTranslate);
         let _value = valueToTranslate;
-        let savedValue =this.translatableObjects[valueToSave];
+        let savedValue = this.translatableObjects[valueToSave];
 
         if (typeof savedValue === 'undefined') {
             savedValue = valueToTranslate;
@@ -573,13 +580,13 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
             const isTranslatableLabel = translationUtility.isTranslationIdentifier(savedValue);
 
             if (!isTranslatableLabel) {
-                if (savedValue !== valueToTranslate){
+                if (savedValue !== valueToTranslate) {
                     savedValue = valueToTranslate;
                 }
                 _value = this._t(valueToTranslate)
 
             } else {
-                if (this._t(savedValue) !== valueToTranslate && translationUtility.hasMultipleIdentifiers(savedValue) ) {
+                if (this._t(savedValue) !== valueToTranslate && translationUtility.hasMultipleIdentifiers(savedValue)) {
                     savedValue = valueToTranslate;
                 }
                 _value = this._t(savedValue);
@@ -629,15 +636,15 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
      */
     public info(message?: any, ...optionalParams: any[]): void {
 
-      let ts = '';
+        let ts = '';
 
-      if (Ch5Debug.CONSOLE_OVERRIDDEN === false) {
-        ts = (new Date()).toISOString();
-      }
-      
-      if (true === this.isDebug()) {
-          console.info(ts, this.getCrId(), ':', message, optionalParams);
-      }
+        if (Ch5Debug.CONSOLE_OVERRIDDEN === false) {
+            ts = (new Date()).toISOString();
+        }
+
+        if (true === this.isDebug()) {
+            console.info(ts, this.getCrId(), ':', message, optionalParams);
+        }
     }
 
     /**
@@ -1079,7 +1086,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
             this.gestureable = this.getAttribute('gestureable') as string;
         }
         this.dir = this.getAttribute('dir') || Ch5Common.DIRECTION[0];
-        if (this.hasAttribute('appendclasswheninviewport')){
+        if (this.hasAttribute('appendclasswheninviewport')) {
             this.appendClassWhenInViewPort = this.getAttribute('appendclasswheninviewport') as string;
             subscribeInViewPortChange(this, (isInViewPort: boolean) => {
                 this.updateElementVisibility(isInViewPort);
@@ -1111,7 +1118,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
     /**
      * Helper method. For internal use.
      */
-    protected clearStringSignalSubscription(sigName: string|null|undefined, subscriptionKey: string) {
+    protected clearStringSignalSubscription(sigName: string | null | undefined, subscriptionKey: string) {
         let oldSig: Ch5Signal<string> | null = null;
         if (sigName) {
             const subSigName: string = Ch5Signal.getSubscriptionSignalName(sigName);
@@ -1125,7 +1132,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
     /**
      * Helper method. For internal use.
      */
-    protected clearBooleanSignalSubscription(sigName: string|null|undefined, subscriptionKey: string) {
+    protected clearBooleanSignalSubscription(sigName: string | null | undefined, subscriptionKey: string) {
         let oldSig: Ch5Signal<boolean> | null = null;
         if (sigName) {
             const subSigName: string = Ch5Signal.getSubscriptionSignalName(sigName);
@@ -1139,7 +1146,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
     /**
      * Helper method. For internal use.
      */
-    protected clearNumberSignalSubscription(sigName: string|null|undefined, subscriptionKey: string) {
+    protected clearNumberSignalSubscription(sigName: string | null | undefined, subscriptionKey: string) {
         let oldSig: Ch5Signal<number> | null = null;
         if ('' !== sigName
             && null !== sigName
@@ -1193,9 +1200,9 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
         }
     }
 
-    protected _attributeValueAsString(attrName:string) {
-        let attributeValue='';
-        if (this.hasAttribute(attrName)){
+    protected _attributeValueAsString(attrName: string) {
+        let attributeValue = '';
+        if (this.hasAttribute(attrName)) {
             attributeValue = '' + this.getAttribute(attrName); // convert to string
         }
         return attributeValue;
@@ -1303,7 +1310,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
         if (value !== this._disabled) {
             this._disabled = this._toBoolean(value);
             if (this._disabled) {
-                this.setAttribute('disabled','');
+                this.setAttribute('disabled', '');
             } else {
                 this.removeAttribute('disabled');
             }
@@ -1314,7 +1321,7 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
         return this._disabled;
     }
 
-    public set gestureable(value:boolean|string) {
+    public set gestureable(value: boolean | string) {
         this.info('set gestureable(\'' + value + '\')');
         const booleanValue = this._toBoolean(value);
 
@@ -1608,17 +1615,17 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
      * @param {string} attribute the attribute name to invoke incompatibility
      */
     protected invokePropIncompatibility(attribute: string): void {
-      switch (attribute) {
-        case 'pagedSwipe':
-          console.warn(this.definePropIncompatibilityInfo(
-            attribute, 
-            [
-              'size', 
-              'endless'
-            ]
-          ));
-          break;
-      }
+        switch (attribute) {
+            case 'pagedSwipe':
+                console.warn(this.definePropIncompatibilityInfo(
+                    attribute,
+                    [
+                        'size',
+                        'endless'
+                    ]
+                ));
+                break;
+        }
     }
 
     /**
@@ -1628,9 +1635,9 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
      * @param {string|boolean} str
      * @returns {boolean}
      */
-    protected _toBoolean(val: any) : boolean{
+    protected _toBoolean(val: any): boolean {
         const str = String(val);
-        switch (str.toLowerCase().trim()){
+        switch (str.toLowerCase().trim()) {
             case "true": case "yes": case "1": return true;
             case "false": case "no": case "0": case null: return false;
             default: return Boolean(false);
@@ -1669,8 +1676,8 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
      * @param {string[]} reasons
      */
     private definePropIncompatibilityInfo(attribute: string, reasons: string[]): string {
-      const reasonsList = reasons.join(',');
-      return `For element #${this.id} - ${attribute} doesn't work as expected. See(${reasonsList})`;
+        const reasonsList = reasons.join(',');
+        return `For element #${this.id} - ${attribute} doesn't work as expected. See(${reasonsList})`;
     }
 
     public updateElementVisibility(visible: boolean) {

--- a/crestron-components-lib/src/ch5-core/ch5-core-intersection-observer.ts
+++ b/crestron-components-lib/src/ch5-core/ch5-core-intersection-observer.ts
@@ -11,7 +11,7 @@ import { Ch5Common } from "../ch5-common/ch5-common";
 
 export class Ch5CoreIntersectionObserver {
 
-    public static observerTreshhold: number = 0.20;
+    public static observerTreshhold = [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 0.92, 0.94, 0.96, 0.98, 1.00];
     public static observerRootMargin: string = '0px';
     private static _instance: Ch5CoreIntersectionObserver;
     private _intersectionObserverConfig: object;
@@ -27,7 +27,7 @@ export class Ch5CoreIntersectionObserver {
         this._intersectionObserver = new IntersectionObserver(this.intersectionObserverCallback, this._intersectionObserverConfig);
     }
 
-    public static getInstance() : Ch5CoreIntersectionObserver {
+    public static getInstance(): Ch5CoreIntersectionObserver {
         if (Ch5CoreIntersectionObserver._instance instanceof Ch5CoreIntersectionObserver) {
             return Ch5CoreIntersectionObserver._instance;
         } else {
@@ -36,16 +36,17 @@ export class Ch5CoreIntersectionObserver {
 
         return Ch5CoreIntersectionObserver._instance;
     }
-    
+
     private intersectionObserverCallback(entries: any[], observer: IntersectionObserver) {
         entries.forEach((entry) => {
             const ch5Component = entry.target as Ch5Common;
+            ch5Component.elementIntersectionEntry = entry as IntersectionObserverEntry;
             ch5Component.elementIsInViewPort = entry.isIntersecting;
             (entry.target as any).viewportCallBack(entry.target as HTMLElement, entry.isIntersecting);
         });
-    } 
+    }
 
-    public observe(element: Element, callback: subscribeInViewPortChangeCallback){
+    public observe(element: Element, callback: subscribeInViewPortChangeCallback) {
         if (!_.isNil(element)) {
             (element as any).viewportCallBack = callback;
             this._intersectionObserver.observe(element);
@@ -59,7 +60,7 @@ export class Ch5CoreIntersectionObserver {
         }
     }
 
-    public disconnect(){
+    public disconnect() {
         if (this._intersectionObserver instanceof IntersectionObserver) {
             this._intersectionObserver.disconnect();
         }


### PR DESCRIPTION
Following Issues are fixed:
1. Fixed snapshot issue to be displayed when the video stops playing through receiveStatePlay.
2. Calculation is done for the stretch=true in both normal mode and full screen mode.
3. Fixed the issue of background cutting when the video starts playing.
4. Stopped retrying to establish connection when the response gets error.
5. Calculation of the position on orientation change.
6. Fixed the bug of tapping the play/stop buttons multiple times to trigger.
7. Fixed the snapShotRefreshRate issue.
8. Fixed the issue of playing and stopping the video based on the visibility of the video.
9. Fixed the controls alignment.
10. Fixed the issue of crashing in multiple video page.