### PR TITLE
Hotfix for intersection observer

### DIFF
--- a/crestron-components-lib/src/ch5-core/ch5-core-intersection-observer.ts
+++ b/crestron-components-lib/src/ch5-core/ch5-core-intersection-observer.ts
@@ -11,7 +11,7 @@ import { Ch5Common } from "../ch5-common/ch5-common";
 
 export class Ch5CoreIntersectionObserver {
 
-    public static observerTreshhold = 0.20;
+    public static observerTreshhold = [0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 0.92, 0.94, 0.96, 0.98, 1.00];
     public static observerRootMargin: string = '0px';
     private static _instance: Ch5CoreIntersectionObserver;
     private _intersectionObserverConfig: object;


### PR DESCRIPTION
# Description

Earlier observerTreshhold value was 0.20 which was changed to Array of Values [0.10, 0.20, 0.30, 0.40, 0.50, 0.60, 0.70, 0.80, 0.90, 0.92, 0.94, 0.96, 0.98, 1.00];.

The ch5Component.elementIsInViewPort will have value true when the threshold is above 0.20 and there is no change compared to the old functionality. We have removed 0.10 from the Array list from the earlier commit.

Fixes # (issue)
The assumption is that the change of the threshold is causing some problem in list as per Andrei, but not confirmed.

## Type of change
Change of values

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
