### PR TITLE
fix(list): null offset size at initialization

### DIFF
--- a/crestron-components-lib/src/ch5-list/ch5-list-animation.ts
+++ b/crestron-components-lib/src/ch5-list/ch5-list-animation.ts
@@ -369,7 +369,9 @@ export class Ch5ListAnimation extends Ch5ListAbstractHelper {
             return this._list.sizeResolver.hiddenListSize;
         }
 
-        this._templateHelper.updateViewportSize();
+        this._templateHelper.updateViewportSize(
+            this._list.sizeResolver.viewPortSize
+        );
 
         const itemsPerPage = this._list.getItemsPerPage();
         const firstItemSize = this._list.getItemSize();

--- a/crestron-components-lib/src/ch5-list/ch5-list-template.ts
+++ b/crestron-components-lib/src/ch5-list/ch5-list-template.ts
@@ -395,7 +395,7 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
         if (this._list.size !== null) {
 
             const itemSize = this._list.isHorizontal ? this._list.itemOffsetWidth : this._list.itemOffsetHeight;
-            const containerSize = this._list.isHorizontal ? this._list.storedOffsetWidth : this._list.storedOffsetHeight;
+            const containerSize = this._list.sizeResolver.viewPortSize;
 
             // used to extract scrollbar size from containerSize if it is endless
             let divListSize = containerSize;
@@ -560,11 +560,21 @@ export class Ch5ListTemplate extends Ch5ListAbstractHelper {
     /**
      * Updates the viewport size
      * 
+     * @param {number} viewportSize specified value for viewportsize
      */
-    public updateViewportSize() {
-        const listViewportBoundingRect: ClientRect | DOMRect = this._list.getBoundingClientRect();
-        this._list.viewportClientHeight = listViewportBoundingRect.height;
-        this._list.viewportClientWidth = listViewportBoundingRect.width;
+    public updateViewportSize(viewportSize: number = 0) {
+
+        if (!viewportSize) {
+            const listViewportBoundingRect: ClientRect | DOMRect = this._list.getBoundingClientRect();
+            viewportSize = this._list.isHorizontal ? listViewportBoundingRect.width : listViewportBoundingRect.height;
+        }
+
+        if (!this._list.isHorizontal) {
+            this._list.viewportClientHeight = viewportSize;
+            return;
+        }
+        
+        this._list.viewportClientWidth = viewportSize;
     }
 
     /**


### PR DESCRIPTION
# Work In Progress
**ToDo:**
- Found an issue with the default angular list (SampleProjects), missing scrollbar

# Description

The offsetWidth/offsetHeight properties has 0 value at initialization. This brokes the functionality for pagedSwipe and the functionality of scrollbar.

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
