### PR TITLE
fix(ch5-button): allow focus on input in showcase touch

### DIFF
--- a/crestron-components-lib/src/ch5-button/ch5-button.ts
+++ b/crestron-components-lib/src/ch5-button/ch5-button.ts
@@ -7,6 +7,7 @@
 
 import { Ch5Common } from "../ch5-common/ch5-common";
 import { Ch5Signal, Ch5SignalBridge, Ch5SignalFactory } from "../ch5-core/index";
+import { isSafariMobile } from '../ch5-core/utility-functions/is-safari-mobile';
 import isNil from 'lodash/isNil';
 
 import {
@@ -1782,8 +1783,8 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
 
     private _onMouseUp() {
         this.cancelPress();
-        // button does not gain focus when its cliked in safari
-        if (isTouchDevice()) {
+        // button does not gain focus when it's cliked in safari mobile
+        if (isTouchDevice() && isSafariMobile()) {
             this._sendOnClickSignal();
         }
     }

--- a/crestron-components-lib/src/ch5-core/utility-functions/is-safari-mobile.ts
+++ b/crestron-components-lib/src/ch5-core/utility-functions/is-safari-mobile.ts
@@ -1,0 +1,16 @@
+// Copyright (C) 2018 to the present, Crestron Electronics, Inc.
+// All rights reserved.
+// No part of this software may be reproduced in any form, machine
+// or natural, without the express written consent of Crestron Electronics.
+// Use of this source code is subject to the terms of the Crestron Software License Agreement
+// under which you licensed this source code.
+
+/**
+ * Returns whether the browser is Safari mobile
+ */
+export function isSafariMobile(): boolean {
+    const ua = window.navigator.userAgent;
+    const iOS = !!ua.match(/iPad/i) || !!ua.match(/iPhone/i);
+    const webkit = !!ua.match(/WebKit/i);
+    return !!(iOS && webkit && !ua.match(/CriOS/i));
+}


### PR DESCRIPTION
## Description
Allow setting focus in a ch5-textinput through the receiveStateFocus signal that is triggered by the clicking of a ch5-button.

**This fix is meant for the showcase app when touch support is enabled.**

### Fixes:
https://crestroneng.atlassian.net/browse/CH5C-802

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
