### PR TITLE
fix(remote-logger): wait for the configuration to be loaded

### DIFF
--- a/crestron-components-lib/src/ch5-logger/appender/AbstractAppender.ts
+++ b/crestron-components-lib/src/ch5-logger/appender/AbstractAppender.ts
@@ -8,12 +8,14 @@
  */
 
 import { LogMessage } from '../helpers/index';
-import { Observable, timer } from 'rxjs';
+import { Observable, timer, BehaviorSubject } from 'rxjs';
 import isNil from 'lodash/isNil';
 
 export abstract class AbstractAppender {
 
   private _sendLogTimeOffset: Observable<number> = {} as Observable<number>;
+  public isInitialized: boolean = false;
+  public isInitializedSubject: BehaviorSubject<boolean> = new BehaviorSubject(this.isInitialized);
 
   public constructor(sendLogTimeOffsetInMiliseconds: number) {
     this.sendLogTimeOffset = timer(sendLogTimeOffsetInMiliseconds);
@@ -33,5 +35,5 @@ export abstract class AbstractAppender {
 
   public abstract configObserver(config: {}, hasConfig: boolean): void;
 
-  public abstract log( data: LogMessage ): void;
+  public abstract log(data: LogMessage): void;
 }

--- a/crestron-components-lib/src/ch5-logger/appender/RemoteAppender.ts
+++ b/crestron-components-lib/src/ch5-logger/appender/RemoteAppender.ts
@@ -57,6 +57,8 @@ export class RemoteAppender extends AbstractAppender {
           responsePromise.then(response => {
             const filter = response.data;
             helper.logFilter = new LogMessagesFilter(filter.level, filter.source, filter.regularExpression);
+            this.isInitialized = true;
+            this.isInitializedSubject.next(true);
           })
         }
       }

--- a/crestron-components-lib/src/ch5-logger/helpers/LogMessage.ts
+++ b/crestron-components-lib/src/ch5-logger/helpers/LogMessage.ts
@@ -16,22 +16,14 @@ export class LogMessage {
     public readonly level: LogLevelEnum = LogLevelEnum.info; // init with lowest log level
     public readonly message: string = '';
     public readonly source: string = '';
-    public canBeDisplayed: boolean = false;
 
     constructor(data: TDataLog, logFilter: LogMessagesFilter) {
 
-        // filter the message / log
-        if (!isNil(logFilter)) {
-            this.canBeDisplayed = logFilter.applyFilter(data);
-        }
-        // populate LogMessage properties only if it can be displayed (no need otherwise)
-        if (this.canBeDisplayed) {
-            const currentDate = new Date();
-            this.date = currentDate;
-            this.message = data.message;
-            this.level = data.level;
-            this.source = data.source;
-        }
+        const currentDate = new Date();
+        this.date = currentDate;
+        this.message = data.message;
+        this.level = data.level;
+        this.source = data.source;
     }
 
     protected getStringTime() {


### PR DESCRIPTION
## Description

A mechanism for queueing messages was implemented.
It queues all messages that arrive but does not send them to the output until the configuration is loaded.

### Fixes:

https://crestroneng.atlassian.net/browse/CH5C-772


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] New and existing unit tests pass locally with my changes
