### PR TITLE
[WIP][DO NOT MERGE] fix(ch5-button): allow focus on textinput

### DIFF
--- a/crestron-components-lib/src/ch5-button/ch5-button.ts
+++ b/crestron-components-lib/src/ch5-button/ch5-button.ts
@@ -1735,7 +1735,9 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
     }
 
     private _onTapAction() {
+        if (!isTouchDevice()) {
             this._sendOnClickSignal();
+        }
 
         if (null !== this._intervalIdForOnTouch) {
             window.clearInterval(this._intervalIdForOnTouch);
@@ -1781,6 +1783,11 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
 
     private _onMouseUp() {
         this.cancelPress();
+
+        // iOS/iPadOS only
+        if (isTouchDevice() && isSafariMobile()) {
+            this._sendOnClickSignal();
+        }
     }
 
     private async _onPress(event: TouchEvent) {
@@ -1848,6 +1855,14 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
 
         inEvent.preventDefault();
         inEvent.stopPropagation();
+
+        // signal is sent here to make sure the button does 	
+        // not gain focus when it should not	
+
+        // on touch devices, focus is gained onTouchEnd
+        if (isTouchDevice()) {
+            this._sendOnClickSignal();
+        }
     }
 
     /**


### PR DESCRIPTION
## Description

The fix relies on detection of touch-capable devices as well as detecting touch-capable iOS/iPadOS devices.
The conditions that were added are needed because the order of events is not persistent among all types of browsers (e.g. focus on an element is gained after touch has ended on mobile, whereas on desktop devices focus is gained immediately after click).

If the signals come from the **emulator**, all examples specified in the JIRA issue work on **all devices** (Chrome desktop, Safari desktop, TSW760, TSW 1060, iOS, iPadOS).

If the signals come from the **control system** (RMC3), all examples work, **except** for iOS and iPadOS.

### Fixes:

https://crestroneng.atlassian.net/browse/CH5C-802

### Test data

1. Showcase example: http://127.0.0.1:8080/ch5-textinput/receive-signal-focus.html
2. Angular Sample App: 
```
<ch5-button type="info" sendEventOnClick="trig1" label="Focus the input"></ch5-button>
<ch5-textinput receiveStateFocus="btn_receive_focus" placeholder="Focus on me"></ch5-textinput>
```


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] Documentation update (add or update existing documentation, no changes to business logic)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] New and existing unit tests pass locally with my changes
