### PR TITLE
fix(showcase): wrong signal name used compared to emulator

### DIFF
--- a/showcase-app/emulator-scenarios/scenario-ch5-textinput-receiving-value-signal.json
+++ b/showcase-app/emulator-scenarios/scenario-ch5-textinput-receiving-value-signal.json
@@ -2,7 +2,7 @@
     "cues": [
       {
         "type": "b",
-        "event": "trig1",
+        "event": "trigger",
         "trigger": true,
         "actions": [
           {


### PR DESCRIPTION
## Description

- wrong signal name compared to the on in the emulator / broken showcase example

### Fixes:

- Improvement / fix not tracked in JIRA

### Test data

- Navigate to http://127.0.0.1:8080/ch5-textinput/receive-signal-value.html, the sendEventOnClick value should now match the one from the emulator (trigger), and the _Hello!_ string will be displayed after clicking the button.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)