### PR TITLE
fix/CH5C-1006-remote-logger-singleton

### DIFF
--- a/crestron-components-lib/src/ch5-logger/appender/AppenderFactory.ts
+++ b/crestron-components-lib/src/ch5-logger/appender/AppenderFactory.ts
@@ -9,13 +9,14 @@
 
 import { AppendersEnum } from '../enums/index';
 import { RemoteAppender } from './RemoteAppender';
+import { TAppenderConfig } from '../types';
 
 export class AppenderFactory {
 
-    public getAppender(appender: AppendersEnum, sendLogTimeOffset: number = 0, config: any) {
+    public getAppender(appender: AppendersEnum, sendLogTimeOffset: number = 0, appenderConfig: TAppenderConfig) {
         
         if (appender === AppendersEnum.remote) {
-            return RemoteAppender.getInstance(sendLogTimeOffset, config);
+            return RemoteAppender.getInstance(sendLogTimeOffset, appenderConfig);
         }
 
         throw new Error('Appender type is invalid');

--- a/crestron-components-lib/src/ch5-logger/appender/RemoteAppender.ts
+++ b/crestron-components-lib/src/ch5-logger/appender/RemoteAppender.ts
@@ -12,24 +12,25 @@ import { RequestService } from "../services/index";
 import { LogEndpointsEnum } from "../enums/index";
 import { LogMessage, LogMessagesFilter } from "../helpers/index";
 import { Logger } from "../logger";
+import { TAppenderConfig } from "../types";
 
 export class RemoteAppender extends AbstractAppender {
     private static _instance: RemoteAppender;
     private _requestService: RequestService = {} as RequestService;
     private _address: string = '';
 
-    public static getInstance(sendLogTimeOffsetInMiliseconds: number, config: any): RemoteAppender{
+    public static getInstance(sendLogTimeOffsetInMiliseconds: number, appenderConfig: TAppenderConfig): RemoteAppender{
       if (RemoteAppender._instance === undefined){
-        RemoteAppender._instance = new RemoteAppender(sendLogTimeOffsetInMiliseconds, config);
+        RemoteAppender._instance = new RemoteAppender(sendLogTimeOffsetInMiliseconds, appenderConfig);
       }
 
       return RemoteAppender._instance;
     }
 
-    private constructor(sendLogTimeOffsetInMiliseconds: number, config: any){
+    private constructor(sendLogTimeOffsetInMiliseconds: number, appenderConfig: TAppenderConfig){
       super(sendLogTimeOffsetInMiliseconds);
 
-      this.setIP(config.host, config.port, config.secure);
+      this.setIP(appenderConfig);
     }
 
     /**
@@ -45,20 +46,18 @@ export class RemoteAppender extends AbstractAppender {
     }
 
     /**
-     * Set the remote server IP
+     * Set the remote server hostname/ip and port
      * Initializing the request for the remote server
      * 
-     * @param {string} ip
-     * @param {string} port 
-     * @param {boolean} secure 
+     * @param {TAppenderConfig} appenderConfig
      */
-    private setIP(ip: string, port?: string, secure?: boolean) {
+    private setIP(appenderConfig: TAppenderConfig) {
 
-        const protocol = secure ? 'https' : 'http';
+        const protocol = appenderConfig.secure ? 'https' : 'http';
 
-        const uri = `${protocol}://${ip}:${port}`;
+        const uri = `${protocol}://${appenderConfig.hostname}:${appenderConfig.port}`;
 
-        this._address = `${ip}:${port}`;
+        this._address = `${appenderConfig.hostname}:${appenderConfig.port}`;
         this.initialiseRequest(uri);        
     }
 

--- a/crestron-components-lib/src/ch5-logger/logger/Logger.ts
+++ b/crestron-components-lib/src/ch5-logger/logger/Logger.ts
@@ -13,12 +13,20 @@ import isNil from 'lodash/isNil';
 import { LogMessagesFilter } from "../helpers/LogMessagesFilter";
 
 export class Logger {
-
+    private static _instance: Logger;
     private _appender: AbstractAppender = {} as AbstractAppender;
     private _logFilter: LogMessagesFilter = new LogMessagesFilter();
     private _messagesQueue: LogMessage[] = [];
 
-    public constructor(appender: AbstractAppender, logFilter?: LogMessagesFilter) {
+    public static getInstance(appender: AbstractAppender, logFilter?: LogMessagesFilter): Logger {
+        if (Logger._instance === undefined) {
+            Logger._instance = new Logger(appender, logFilter)
+        }
+
+        return Logger._instance;
+    }
+
+    private constructor(appender: AbstractAppender, logFilter?: LogMessagesFilter) {
         if (!(appender instanceof AbstractAppender)) {
             throw Error('Appender is not defined');
         }

--- a/crestron-components-lib/src/ch5-logger/types/index.ts
+++ b/crestron-components-lib/src/ch5-logger/types/index.ts
@@ -14,3 +14,9 @@ export type TDataLog = {
 }
 
 export type TLogMessageType = any[];
+
+export type TAppenderConfig = {
+    hostname: string;   // hostname or IP
+    port: string;
+    secure: boolean
+};

--- a/crestron-components-lib/src/ch5-logger/utility/getLogger.ts
+++ b/crestron-components-lib/src/ch5-logger/utility/getLogger.ts
@@ -11,7 +11,7 @@ import { LogMessagesFilter } from '../helpers/LogMessagesFilter';
 
 export function getLogger(appender: AbstractAppender, overrideGlobalConsole?: boolean, logFilter?: LogMessagesFilter, ) {
 
-  const logger = new Logger(appender, logFilter);
+  const logger = Logger.getInstance(appender, logFilter);
   appender.configObserver(logger, !!logFilter);
 
   

--- a/crestron-components-lib/src/ch5-logger/utility/getRemoteAppender.ts
+++ b/crestron-components-lib/src/ch5-logger/utility/getRemoteAppender.ts
@@ -8,12 +8,14 @@
 import { AppenderFactory } from '../appender/AppenderFactory';
 import { AppendersEnum } from '../enums/index';
 import { RemoteAppender } from '../appender/RemoteAppender';
+import { TAppenderConfig } from '../types';
 
 
-export function getRemoteAppender(host: string, port: string, secure: boolean): RemoteAppender {
+export function getRemoteAppender(hostname: string, port: string, secure: boolean): RemoteAppender {
 
     const appenderFactory = new AppenderFactory();
-    const remoteAppender = appenderFactory.getAppender(AppendersEnum.remote, 0, {host, port, secure}) as RemoteAppender;
+    const appenderConfig: TAppenderConfig = {hostname, port, secure};
+    const remoteAppender = appenderFactory.getAppender(AppendersEnum.remote, 0, appenderConfig) as RemoteAppender;
 
     return remoteAppender;
 }


### PR DESCRIPTION
## Description

Ensure that the appender and the logger are instantiated only once - at the beginning.
The appender and logger that are instantiated first cannot be modified.

### Fixes:

It is an improvement, but may also fix https://crestroneng.atlassian.net/browse/CH5C-1006

### Test data

Add the following code inside any application that uses the components library and check the logs from the **remote logger** container.
You should see the following two lines:

-  _same appender instance_
- _same logger instance_

```
    const appender = CrComLib.getRemoteAppender('127.0.0.1', '8080');
    const logger = CrComLib.getLogger(appender, true);
    const appender2 = CrComLib.getRemoteAppender('127.0.0.1', '8085');
    const logger2 = CrComLib.getLogger(appender2, true);

    if (appender2 === appender) {
      logger.warn('same appender instance');
    } else {
      logger.warn('not the same appender');
    }

    if (logger === logger2) {
      logger.warn('same logger instance');
    } else {
      logger.warn('not the same logger');
    }
```

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
