### PR TITLE
csig.library.ver and csig.library.date statenames changed to start with 'Csig.'

### DIFF
--- a/crestron-components-lib/src/ch5-core/ch5-version.ts
+++ b/crestron-components-lib/src/ch5-core/ch5-version.ts
@@ -17,8 +17,8 @@ enum ch5VersionError {
 export const version = !!process.env.BUILD_VERSION ? process.env.BUILD_VERSION : ch5VersionError.versionNotSet; // 'X.XX.XX.XX'
 export const buildDate = !!process.env.BUILD_DATE ? process.env.BUILD_DATE : ch5VersionError.invalidDate; // 'YYYY-MM-DD'
 
-export const signalNameForLibraryVersion: string = 'csig.library.ver';
-export const signalNameForLibraryBuildDate: string = 'csig.library.date';
+export const signalNameForLibraryVersion: string = 'Csig.library.ver';
+export const signalNameForLibraryBuildDate: string = 'Csig.library.date';
 
 class Ch5Version {
 

--- a/showcase-app/src/index.njk
+++ b/showcase-app/src/index.njk
@@ -66,8 +66,8 @@ layout: base.njk
                         </ul>
                     </div>
                     <p>
-                        CH5 version is <span data-ch5-textcontent="csig.library.ver"></span>
-                        dated <span data-ch5-textcontent="csig.library.date"></span>
+                        CH5 version is <span data-ch5-textcontent="Csig.library.ver"></span>
+                        dated <span data-ch5-textcontent="Csig.library.date"></span>
                     </p>
                 </div>
             </div>


### PR DESCRIPTION
Changed the name of signal names to match the conventions of reserve joins

## Description

- Changed the state provided by the library of csig.library.ver and csig.library.date to match convention of reserve joins to start with Csig. (note the capitalization of C).

### Test data

- Not relevant

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [x] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas (Not applicable)
- [ ] I have made corresponding changes to the documentation (Not applicable)
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes 
