### PR TITLE
fix duplicate  join for both tap/click and press and hold on iOS

### DIFF
--- a/crestron-components-lib/src/ch5-button/ch5-button.ts
+++ b/crestron-components-lib/src/ch5-button/ch5-button.ts
@@ -375,6 +375,11 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
     private _lastTapTime: number = 0;
 
     /**
+     * this is last time press was released  
+     */
+    private _lastPressTime: number = 0;
+
+    /**
      * Events
      * click - inherited
      * focus - inherited
@@ -1930,7 +1935,14 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
 
         // iOS/iPadOS only
         if (isTouchDevice() && isSafariMobile()) {
-            this._sendOnClickSignal();
+            const timeSinceLastPress = new Date().valueOf() - this._lastPressTime;
+            if (timeSinceLastPress  < 100) {
+                // sometimes a both click and press can happen on iOS/iPadOS, don't publish both
+                this.info('Ch5Button debouncing duplicate press/hold and click ' + timeSinceLastPress);
+            }
+            else {
+                this._sendOnClickSignal();
+            }
         }
     }
 
@@ -1959,6 +1971,7 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
                 window.clearInterval(this._intervalIdForOnTouch);
                 this.sendValueForOnTouchSignal(false);
                 this._intervalIdForOnTouch = null;
+                this._lastPressTime = new Date().valueOf();
             }
         }
     }


### PR DESCRIPTION
In certain circumstances both are published on single interaction with control system 

## Description

issue ch5c-1071
- press of button around 450ms will provide a join for both a sendEventOnTouch and sentEventOnClick 
- this is addressed with debounce logic 

### Fixes:

https://crestroneng.atlassian.net/browse/CH5C-1071 

### Test data

control system and project provided in jira issue

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
