### PR TITLE
relative location of showcase app moved to /Content/Topics/ShowcaseApp

### DIFF
--- a/showcase-app/metalsmith.json
+++ b/showcase-app/metalsmith.json
@@ -1,11 +1,11 @@
 {
   "source": "./src",
-  "destination": "./dist/Content/Topics/ShowcaseApp",
+  "destination": "./dist/downloads/ShowcaseApp",
   "clean": true,
   "metadata": {
     "title": "Showcase App",
     "description": "Showcase App for Crestron Components",
-    "siteurl":"/Content/Topics/ShowcaseApp/"
+    "siteurl":"/downloads/ShowcaseApp/"
   },
   "plugins": {
     "metalsmith-debug":{},


### PR DESCRIPTION
## Description

- Integration with documentation "microsite" requires the relative location of the showcase app be /Content/Topics/ShowcaseApp

## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [ ] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
