### PR TITLE
feat(ch5-core): adds webxpanel to the signal bridge

### DIFF
--- a/crestron-components-lib/src/ch5-core/interfaces-sig-com.ts
+++ b/crestron-components-lib/src/ch5-core/interfaces-sig-com.ts
@@ -54,6 +54,12 @@ export interface ISigComSendWebkit {
     messageHandlers: ISigComSendWebkitMessageHandlers;
 }
 
+export type ISWebXPanel = {
+    bridgeSendBooleanToNative(signalName: string, value: boolean | object):void;
+    bridgeSendIntegerToNative(signalName: string, value: number):void;
+    bridgeSendStringToNative(signalName: string, value: string):void;
+}
+
 export interface ISigComSendWebkitMessageHandlers {
     bridgeSendBooleanToNative:IWebkitMessageHandler;
     bridgeSendIntegerToNative:IWebkitMessageHandler;


### PR DESCRIPTION
 Description

This changes helps the library to support the information travel through webxpanel to the CCS.

### Fixes:

https://corebuild.atlassian.net/browse/WXP-52

### Test data

- Load the webxpanel library first, then initialize the webxpanel and load the ch5-library build.

## Type of change

Delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
