### PR TITLE
CH5C-1298

### DIFF
--- a/crestron-components-lib/src/ch5-core/utility-functions/subscribe-signal-script.ts
+++ b/crestron-components-lib/src/ch5-core/utility-functions/subscribe-signal-script.ts
@@ -59,7 +59,7 @@ export function subscribeStateScript(signalScript: string,
     }
 
     // parse and extract signal names
-    signalScript.replace(/{{([bns]\.([A-Za-z]|[0-9])[A-Za-z0-9_]*)}}/g,
+    signalScript.replace(/{{([bns]\.([A-Za-z]|[0-9])([A-Za-z0-9_.])*)}}/g,
         (substring: string, ...args: any[]): string => {
             if (typeof args[0] === "undefined") {
                 return '';
@@ -74,7 +74,9 @@ export function subscribeStateScript(signalScript: string,
     let item: any = sigTokensIterator.next();
     const subKeys: TSigNameTypeSub[] = [];
     while (typeof item.value !== "undefined") {
-        [sigType, sigName] = item.value.split('.');
+        sigType = item.value.split('.')[0];
+        const joinsList = (item.value.split('.')).slice(1);
+        sigName = joinsList.join(".");
 
         // augment signal name in case of join numbers
         sigName = Ch5Signal.getSubscriptionSignalName(sigName);
@@ -116,7 +118,9 @@ function _callbackForSignalScriptOnSignalUpdate(signalTokens: Set<string>,
     let sigName = '';
     let sigType = '';
     while (typeof item.value !== "undefined") {
-        [sigType, sigName] = item.value.split('.');
+        sigType = item.value.split('.')[0];
+        const joinsList = (item.value.split('.')).slice(1);
+        sigName = joinsList.join(".");
         const sigVal = getState(sigType as TSignalNonStandardTypeName,sigName);
         if (sigVal === null) {
             processedTemplate = defaultValue;


### PR DESCRIPTION
Parse multiple dot separator

## Description
Fails to match script names with multiple separator.
"n.signal_strength_fb" matches, but does not match "n.DMP40.signal_strength_fb".  This issue has been fixed.

### Fixes:
https://crestroneng.atlassian.net/browse/CH5C-1298

## Type of change
Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [ ] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
