### PR TITLE
CH5C-1292 issue fixed

### DIFF
--- a/crestron-components-lib/src/ch5-triggerview/ch5-triggerview-slides-manager.ts
+++ b/crestron-components-lib/src/ch5-triggerview/ch5-triggerview-slides-manager.ts
@@ -202,7 +202,7 @@ export class Ch5TriggerViewSlidesManager {
    */
   public destroySwiper() {
     if (this.swiperIsActive()) {
-      if (!!this._swiper && !!this._swiper.$el) {
+      if (this._swiper && this._swiper.$el) {
         this._swiper!.destroy(true, false);
       }
     }


### PR DESCRIPTION
`<ch5-triggerview>` in `<template>` causes error in `<ch5-template>`.

## Description
A check has been added to identify whether the element exists in Swiper to avoid undefined error.

### Fixes:
https://crestroneng.atlassian.net/browse/CH5C-1292

### Test data
`<template id="abc"> 
<ch5-triggerview></ch5-triggerview>
</template>
<ch5-template templateid="abc"></ch5-template>`

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [ ] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
