### PR TITLE
Fixes label updates through receiveStateLabel when the component provides translations through a local label attribute

### DIFF
--- a/crestron-components-lib/src/ch5-common/ch5-common.ts
+++ b/crestron-components-lib/src/ch5-common/ch5-common.ts
@@ -607,10 +607,21 @@ export class Ch5Common extends HTMLElement implements ICh5CommonAttributes {
     public _getTranslatedValue(valueToSave: string, valueToTranslate: string) {
 
         const translationUtility = Ch5TranslationUtility.getInstance();
-        const isTranslatableValue = translationUtility.isTranslationIdentifier(valueToTranslate);
+        
+        let translationKey = valueToTranslate;;
         let _value = valueToTranslate;
         let savedValue = this.translatableObjects[valueToSave];
-
+        
+        if (savedValue === valueToTranslate) {
+            translationKey = savedValue;
+        }
+        
+        const isTranslatableValue = translationUtility.isTranslationIdentifier(translationKey);
+        
+        if (!isTranslatableValue) {
+            return valueToTranslate;
+        }
+        
         if (typeof savedValue === 'undefined') {
             savedValue = valueToTranslate;
 


### PR DESCRIPTION
## Description
When label is used in combination with receiveStateLabel and contains translation identifiers the label is not updated.

### Test data
```js
  <ch5-button
       sendeventonclick="ContactList.Contact[0].SetContactSelected"
       class="shadow-pulse-gradient-button"
       customClass="gradient-button--peach"
       shape="rounded-rectangle"
       label="-+buttons.gradient.btn.peach+-"
       receivestatelabel="18"
></ch5-button>
```
## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [ ] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
