### PR TITLE
fix(signal-bridge): add missing send object to native in webxpanel

### DIFF
--- a/crestron-components-lib/src/ch5-core/ch5-signal-bridge.ts
+++ b/crestron-components-lib/src/ch5-core/ch5-signal-bridge.ts
@@ -60,6 +60,7 @@ export class Ch5SignalBridge {
                 isFunction(CommunicationInterface.bridgeSendBooleanToNative)
                 && isFunction(CommunicationInterface.bridgeSendIntegerToNative)
                 && isFunction(CommunicationInterface.bridgeSendStringToNative)
+                && isFunction(CommunicationInterface.bridgeSendObjectToNative)
             );
 
         if (this._isWebXPanel) {
@@ -301,6 +302,8 @@ export class Ch5SignalBridge {
             JSInterface.bridgeSendObjectToNative(signalName, JSON.stringify(value));
         } else if (this._isWebKit) {
             webkit.messageHandlers.bridgeSendObjectToNative.postMessage(this.createPMParam(signalName, value));
+        } else if (this._isWebXPanel) {
+            CommunicationInterface.bridgeSendObjectToNative(signalName, JSON.stringify(value));
         } else {
             // TODO find a way to use this without interfering with the mocha tests
             // throw new Error('sendObjectToNative() not implemented on this platform');

--- a/crestron-components-lib/src/ch5-core/interfaces-sig-com.ts
+++ b/crestron-components-lib/src/ch5-core/interfaces-sig-com.ts
@@ -55,9 +55,10 @@ export interface ISigComSendWebkit {
 }
 
 export type ISWebXPanel = {
-    bridgeSendBooleanToNative(signalName: string, value: boolean | object):void;
-    bridgeSendIntegerToNative(signalName: string, value: number):void;
-    bridgeSendStringToNative(signalName: string, value: string):void;
+    bridgeSendBooleanToNative(signalName: string, value: boolean | object): void;
+    bridgeSendIntegerToNative(signalName: string, value: number): void;
+    bridgeSendStringToNative(signalName: string, value: string): void;
+    bridgeSendObjectToNative(signalName: string, jsonEncodedString: string): void;
 }
 
 export interface ISigComSendWebkitMessageHandlers {


### PR DESCRIPTION
## Description

- Add missing send object to native method for webxpanel

### Test data

- Use crcomlib within a sample project and send repeated digitals

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
