### PR TITLE
Fixes button label when receives blank values from CCS

### DIFF
--- a/crestron-components-lib/src/ch5-button/ch5-button.ts
+++ b/crestron-components-lib/src/ch5-button/ch5-button.ts
@@ -1663,7 +1663,7 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
         }
 
         this._subReceiveLabel = receiveSignal.subscribe((newValue: string) => {
-            if ('' !== newValue && newValue !== this.label) {
+            if (newValue !== this.label) {
                 this.setAttribute('label', newValue);
             }
         });


### PR DESCRIPTION
## Description

Adjusts the receiveStateLabel for button to allow blank values received from CCS

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [ ] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
