### PR TITLE
fix(button): add missing aria-label functionality

### DIFF
--- a/crestron-components-lib/src/ch5-button/ch5-button.ts
+++ b/crestron-components-lib/src/ch5-button/ch5-button.ts
@@ -871,6 +871,7 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
         let hasIcon = false;
         let hasLabel = false;
         let hasImage = false;
+        let hasAriaLabel = false;
 
         if (this.hasAttribute('iconclass') && '' !== this.getAttribute('iconclass')) {
             hasIcon = true;
@@ -885,9 +886,20 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
             hasLabel = true;
         }
 
+        if (this.hasAttribute('aria-label') && '' !== this.getAttribute('aria-label')) {
+            hasAriaLabel = true;
+        }
+
         // updates the iconposition ( otherwise it might use the previous value of the attribute )
         if (this.hasAttribute('iconposition')) {
             this.iconPosition = this.getAttribute('iconposition') as TCh5ButtonIconPosition;
+        }
+
+        if (!hasLabel && hasAriaLabel && hasImage) {
+            const ariaLabel = this.getAttribute('aria-label');
+            if (ariaLabel) {
+                this._elImg.setAttribute('alt', ariaLabel);
+            }
         }
 
         if (hasLabel && hasIcon) {
@@ -941,6 +953,7 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
                 this._elIcon.remove();
             }
             if (hasLabel) {
+                this._elImg.setAttribute('alt', "");
                 if ((this._elLabel as any).isConnected === false) {
                     this._elButton.appendChild(this._elLabel);
                 } else if (this._elImg.parentNode !== (this._elButton as Node)) {


### PR DESCRIPTION
## Description

Adds missing aria-label functionality 

### Fixes: https://crestroneng.atlassian.net/projects/HTML5X/issues/HTML5X-14

### Test data

Add the following code snippet to the showcase app:
```
<ch5-button
      type="text"
      shape="rectangle"
      label="PNG Icon Button 1"
      iconUrl="https://img.icons8.com/material/24/000000/search.png"
></ch5-button>

<ch5-button
      type="text"
      shape="rectangle"
      label="PNG Icon Button 2"
></ch5-button>


<ch5-image
  aria-label="PNG Icon Button 3"
  url="https://img.icons8.com/material/24/000000/search.png"
></ch5-image>

<ch5-button
  aria-label="PNG Icon Button 4"
  iconurl="https://img.icons8.com/material/24/000000/search.png"
></ch5-button>
```

Use NVDA to validate that the screen reader is able to read the aria-label or label attribute.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
