### PR TITLE
Adding repeat digital to send event on click.

### DIFF
--- a/crestron-components-lib/src/ch5-button/ch5-button.ts
+++ b/crestron-components-lib/src/ch5-button/ch5-button.ts
@@ -2035,16 +2035,24 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
      * Sends the signal passed via sendEventOnClick or sendEventOnTouch
      */
     private _sendOnClickSignal(): void {
-        let sigClick: Ch5Signal<boolean> | null = null;
+        //let sigClick: Ch5Signal<boolean> | null = null;
 
         if (this._sigNameSendOnClick) {
-            sigClick = Ch5SignalFactory.getInstance()
-                .getBooleanSignal(this._sigNameSendOnClick);
+            // sigClick = Ch5SignalFactory.getInstance()
+            //     .getBooleanSignal(this._sigNameSendOnClick);
 
-            if (sigClick !== null) {
-                sigClick.publish(true);
-                sigClick.publish(false);
+            // if (sigClick !== null) {
+            //     sigClick.publish(true);
+            //     sigClick.publish(false);
+            // }
+            const sigClickAsRptDigital: Ch5Signal<object | boolean> | null = Ch5SignalFactory.getInstance()
+                .getObjectAsBooleanSignal(this._sigNameSendOnClick);
+            if (sigClickAsRptDigital !== null) {
+                sigClickAsRptDigital.publish({ [Ch5SignalBridge.REPEAT_DIGITAL_KEY]: true});                                
+                sigClickAsRptDigital.publish({ [Ch5SignalBridge.REPEAT_DIGITAL_KEY]: false});     
             }
+
+          
         }
     }
 


### PR DESCRIPTION
This changes the CH5 button behavior to send a repeat digital upon button press/release instead of a regular button press/release. 
Sending a repeat digital for every button press will prevent a situation where a digital can get permanently latched high if the corresponding button release doesn't get sent to the control system, as result of some unexpected event e.g. network outage.


## Type of change

Delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)


