### PR TITLE
fix(ch5-button): repeatdigital is sent on tap

### DIFF
--- a/crestron-components-lib/src/ch5-button/ch5-button.ts
+++ b/crestron-components-lib/src/ch5-button/ch5-button.ts
@@ -2124,24 +2124,16 @@ export class Ch5Button extends Ch5Common implements ICh5ButtonAttributes {
      * Sends the signal passed via sendEventOnClick or sendEventOnTouch
      */
     private _sendOnClickSignal(): void {
-        // let sigClick: Ch5Signal<boolean> | null = null;
+        let sigClick: Ch5Signal<boolean> | null = null;
 
         if (this._sigNameSendOnClick) {
-            // sigClick = Ch5SignalFactory.getInstance()
-            //     .getBooleanSignal(this._sigNameSendOnClick);
+            sigClick = Ch5SignalFactory.getInstance()
+                .getBooleanSignal(this._sigNameSendOnClick);
 
-            // if (sigClick !== null) {
-            //     sigClick.publish(true);
-            //     sigClick.publish(false);
-            // }
-            const sigClickAsRptDigital: Ch5Signal<object | boolean> | null = Ch5SignalFactory.getInstance()
-                .getObjectAsBooleanSignal(this._sigNameSendOnClick);
-            if (sigClickAsRptDigital !== null) {
-                sigClickAsRptDigital.publish({ [Ch5SignalBridge.REPEAT_DIGITAL_KEY]: true});                                
-                sigClickAsRptDigital.publish({ [Ch5SignalBridge.REPEAT_DIGITAL_KEY]: false});     
+            if (sigClick !== null) {
+                sigClick.publish(true);
+                sigClick.publish(false);
             }
-
-          
         }
     }
 


### PR DESCRIPTION
## Description
Fixes the ch5-button repeat digital to be sent only on press & hold

### Fixes:

https://crestroneng.atlassian.net/browse/HTML5X-42

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [ ] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [x] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
