### PR TITLE
fix(ch5-spinner): freeze visible items to 1 when the spinner size is reduced

### DIFF
--- a/crestron-components-lib/src/ch5-spinner/ch5-spinner.ts
+++ b/crestron-components-lib/src/ch5-spinner/ch5-spinner.ts
@@ -1091,7 +1091,6 @@ export class Ch5Spinner extends Ch5Common implements ICh5SpinnerAttributes {
     }
 
     if (items !== this.visibleItemScroll) {
-      this.setAttribute('visibleItemScroll', items + '');
       this.repaint();
     }
 


### PR DESCRIPTION
## Description
Fix the issue ch5-spinner resizing issue. The problem was that if the ch5-spinner have only 1 item when the size is increased the visible items doesn't increase. It will still display only 1 items 
### Fixes:

https://crestroneng.atlassian.net/browse/CH5C-1266

## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update (add or update existing documentation, no changes to business logic)
- [ ] Other (refactor, style changes and so on, include an explanation in the description)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
