### PR TITLE
fix/html5x-53-prevent-textinput-from-publishing-multiple-times

### DIFF
--- a/crestron-components-lib/src/ch5-textinput/ch5-textinput.ts
+++ b/crestron-components-lib/src/ch5-textinput/ch5-textinput.ts
@@ -2234,7 +2234,7 @@ export class Ch5Textinput extends Ch5CommonInput implements ICh5TextInputAttribu
      */
     protected attachEventListeners(): void {
         this.info("<ch5-textinput />.attachEventListeners()");
-
+        this.removeEvents();
         this._onChangeListener = this._onChange.bind(this);
         this._onBlurListener = this._onBlur.bind(this);
         this._onFocusListener = this._onFocus.bind(this);
@@ -2259,11 +2259,11 @@ export class Ch5Textinput extends Ch5CommonInput implements ICh5TextInputAttribu
 
         super.removeEventListeners();
 
-        if (!_.isEmpty(this._elInput)) {
-            this._elInput.removeEventListener('change', this._onChangeListener);
+        if (!_.isElement(this._elInput)) {
+            this._elInput.removeEventListener('keyup', this._onChangeListener);
             this._elInput.removeEventListener('focus', this._onFocusListener);
             this._elInput.removeEventListener('blur', this._onBlurListener);
-            this._elInput.removeEventListener('keypress', this._onKeyPressListener);
+            this._elInput.removeEventListener('input', this._onKeyPressListener);
         }
     }
 


### PR DESCRIPTION
## Description

Adds proper event listeners and makes sure they are removed in order to avoid sending the same signal multiple times

### Fixes:

https://crestroneng.atlassian.net/browse/HTML5X-53


## Type of change

Delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
