### PR TITLE
fix(textinput): prevent publishing twice on each keystroke

### DIFF
--- a/crestron-components-lib/src/ch5-textinput/ch5-textinput.ts
+++ b/crestron-components-lib/src/ch5-textinput/ch5-textinput.ts
@@ -1901,8 +1901,6 @@ export class Ch5Textinput extends Ch5CommonInput implements ICh5TextInputAttribu
             this._dirty = true;
             this._clean = false;
             this.dirtyValue = currentElement.value
-
-            this._onChangeSignal(currentElement, currentElement.value);
         }
 
     }


### PR DESCRIPTION
## Description

Prevents duplicate publishing of event on each keystroke

### Fixes:

https://crestroneng.atlassian.net/browse/HTML5X-53


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
